### PR TITLE
Added an own implementation of the handleBatch function

### DIFF
--- a/src/HttpHandler.php
+++ b/src/HttpHandler.php
@@ -183,6 +183,30 @@ class HttpHandler extends AbstractProcessingHandler
 	}
 
 	/**
+	 * Handles a set of records at once.
+	 *
+	 * @param  array  $records The records to handle (an array of record arrays)
+	 * @return bool
+	 */
+	public function handleBatch(array $records)
+	{
+		foreach ($records as $key => $record) {
+	        if ($this->isHandling($record)) {
+	        	$record = $this->processRecord($record);
+	    		$records['records'][] = $record;
+	    	}
+
+			unset($records[$key]);
+	    }
+
+	    $records['formatted'] = $this->getFormatter()->formatBatch($records['records'] ?? []);
+
+	    $this->write($records);
+
+	    return false === $this->bubble;
+	}
+
+	/**
      * Gets the default formatter.
      *
      * @return \Monolog\Formatter\JsonFormatter


### PR DESCRIPTION
#### Details
Overrides the default method `public function handleBatch(array $records);` to make use of the formatters `public function formatBatch(array $records);` method. All records can now be written out in one write call.